### PR TITLE
Customized it for both my device trackpads

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,35 +2,94 @@
 
 import subprocess
 import shlex
+import sys
 
-# Returns whether the keyboard input was fired.
-def parse_twofingers_action(line):
-    device, event, time, details = line.strip().split(maxsplit=3)
-    if event == 'POINTER_SCROLL_FINGER':
-        vert, v_value, horiz, h_value, unused = details.split(maxsplit=4)
-        # action was not vertical scrolling
-        if vert.strip() == 'vert' and v_value.strip() == '0.00/0.0':
-            l, r = h_value.split('/')
-            if (float(l) > 5): # The action was like forward
-                subprocess.Popen(shlex.split('xdotool key alt+Left'))
+# Default thresholds for different devices
+dev_thresh = {
+    "lenovo": {"in": 0.8, "out": 1.2},
+    "apple": {"in": 0.9, "out": 1.1}
+}
+
+# Determine device type from command-line arguments
+dev = "lenovo"  # Default device type
+if len(sys.argv) > 1:
+    dev = sys.argv[1]
+    if dev not in dev_thresh:
+        print(f"Device '{dev}' not recognized. Using default.")
+        dev = "lenovo"
+
+pinch_in_progress = False
+last_scale = 1.0
+
+def parse_twofingers(line):
+    # Implement your logic for two-finger actions here
+    pass
+
+def parse_pinch(line):
+    global pinch_in_progress, last_scale
+
+    if 'GESTURE_PINCH_BEGIN' in line:
+        pinch_in_progress = True
+        last_scale = 1.0
+        return False
+
+    elif 'GESTURE_PINCH_UPDATE' in line and pinch_in_progress:
+        try:
+            scale = float(line.split()[-3])
+            if scale < dev_thresh[dev]["in"]:
+                subprocess.Popen(shlex.split('xdotool key Ctrl+minus'))
+                pinch_in_progress = False
                 return True
-            if (float(l) < -5): # The action like backward
-                subprocess.Popen(shlex.split('xdotool key alt+Right'))
+            elif scale > dev_thresh[dev]["out"]:
+                subprocess.Popen(shlex.split('xdotool key Ctrl+plus'))
+                pinch_in_progress = False
                 return True
+        except ValueError as e:
+            print("Error parsing line:", line)
+            print("Exception:", e)
+            return False
+
+    elif 'GESTURE_PINCH_END' in line:
+        pinch_in_progress = False
+        return False
+
+    return False
+
+def parse_swipe(line, dev):
+    if 'POINTER_SCROLL_FINGER' in line:
+        try:
+            parts = line.split()
+            horiz_index = parts.index('horiz')
+            horiz_scroll = float(parts[horiz_index + 1].split('/')[0])
+
+            swipe_thresh = 5.0
+            if dev == "apple":
+                # Reverse gestures for Apple Magic Trackpad
+                left_action = 'xdotool key alt+Right'
+                right_action = 'xdotool key alt+Left'
+            else:
+                left_action = 'xdotool key alt+Left'
+                right_action = 'xdotool key alt+Right'
+
+            if horiz_scroll > swipe_thresh:
+                subprocess.Popen(shlex.split(left_action))
+                return True
+            elif horiz_scroll < -swipe_thresh:
+                subprocess.Popen(shlex.split(right_action))
+                return True
+        except (ValueError, IndexError) as e:
+            print("Error parsing line:", line)
+            print("Exception:", e)
+
     return False
 
 def main():
     command = 'stdbuf -oL -- libinput debug-events'
     cmd = subprocess.Popen(shlex.split(command), stdout=subprocess.PIPE, bufsize=1, universal_newlines=True)
-    ignore = 0
+
     for line in cmd.stdout:
-        # skip 10 lines if an action was fired.
-        if 0 < ignore:
-            ignore = ignore - 1
-            continue
-        fired = parse_twofingers_action(line)
-        if fired:
-            ignore = 10
+        if parse_twofingers(line) or parse_pinch(line) or parse_swipe(line, dev):
+            pass
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Device-Specific Thresholds: It incorporates device-specific thresholds for pinch gestures, allowing different behaviors for devices like Lenovo touchpads and Apple Magic Trackpads.

Command-Line Device Selection: The script can be run with a command-line argument to specify the device type ('apple' or 'lenovo'), which adjusts the pinch gesture thresholds and swipe actions accordingly.

Reversed Swipe Gestures for Apple Trackpad: Specifically for the Apple Magic Trackpad, the script reverses the swipe gestures, where a swipe to the left triggers a forward action and a swipe to the right triggers a backward action.

Error Handling Enhancements: Improved error handling in parsing the swipe gestures, making the script more robust against unexpected input formats.